### PR TITLE
Adds test suite and CI to run them on PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Build & Test
+
+on:
+  # Trigger the workflow every time a push is made to 'master'
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  # Allows you to run this workflow manually from the Actions tab on GitHub.
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install & Build
+        uses: withastro/action@v2
+      - name: Test
+        run: bun test

--- a/generate-middleware.ts
+++ b/generate-middleware.ts
@@ -24,13 +24,10 @@ fs.readdir(srcDir, (err, files) => {
   files.forEach((file) => {
     if (!file.startsWith("index.")) {
       const fileNameWithoutExt = path.parse(file).name;
-      const htmlContent = `<meta charset="utf-8" />
+      const htmlContent = `<meta charset="utf-8"/>
 <title>Redirecting to https://ladybird.org/${fileNameWithoutExt}/</title>
-<meta
-  http-equiv="refresh"
-  content="0; URL=http://ladybird.org/${fileNameWithoutExt}/"
-/>
-<link rel="canonical" href="http://ladybird.org/${fileNameWithoutExt}/" />`;
+<meta http-equiv="refresh" content="0; URL=http://ladybird.org/${fileNameWithoutExt}/"/>
+<link rel="canonical" href="http://ladybird.org/${fileNameWithoutExt}/"/>`;
       const distFilePath = path.join(distDir, `${fileNameWithoutExt}.html`);
 
       fs.writeFile(distFilePath, htmlContent, (err) => {

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,0 +1,36 @@
+import { expect, test, describe } from "bun:test";
+import fs from "fs";
+import path from "path";
+
+const rootDir: string = path.join(__dirname, "../");
+
+describe("Markdown Rendering", () => {
+  const srcDir = path.join(rootDir, "/src/pages");
+  const distDir = path.join(rootDir, "/dist");
+
+  const mdFiles = fs.readdirSync(srcDir).filter((file) => file.endsWith(".md"));
+  //<h1>{frontmatter.title}</h1>
+  test("Pages Exist", () => {
+    mdFiles.forEach((file) => {
+      const htmlFile = file.replace(".md", ".html");
+      const htmlFilePath = path.join(distDir, htmlFile);
+      expect(fs.existsSync(htmlFilePath)).toBe(true);
+    });
+  });
+
+  test("Layouts Applied", () => {
+    mdFiles.forEach((file) => {
+      const htmlFile = file.replace(".md", "/index.html");
+      const htmlFilePath = path.join(distDir, htmlFile);
+      const htmlContent = fs.readFileSync(htmlFilePath, "utf-8");
+      const fileContent = fs.readFileSync(path.join(srcDir, file), "utf-8");
+      const frontMatterMatch = fileContent.match(/^title:\s*(.*)$/m);
+      const frontMatterTitle = frontMatterMatch
+        ? frontMatterMatch[1]
+        : file.replace(".md", "");
+      const h1Tag = `<h1>${frontMatterTitle}</h1>`;
+
+      expect(htmlContent.includes(h1Tag)).toBe(true);
+    });
+  });
+});

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,33 @@
+import { expect, test, describe } from "bun:test";
+import fs from "fs";
+import path from "path";
+
+const rootDir: string = path.join(__dirname, "../");
+
+describe("Middleware Compilation", () => {
+  const srcDir = path.join(rootDir, "/src/pages");
+  const distDir = path.join(rootDir, "/dist");
+
+  const mdFiles = fs.readdirSync(srcDir).filter((file) => file.endsWith(".md"));
+
+  test("HTML Redirects Exist", () => {
+    mdFiles.forEach((file) => {
+      const htmlFile = file.replace(".md", ".html");
+      const htmlFilePath = path.join(distDir, htmlFile);
+      expect(fs.existsSync(htmlFilePath)).toBe(true);
+    });
+  });
+
+  test("Redirects Work", () => {
+    mdFiles.forEach((file) => {
+      const htmlFile = file.replace(".md", ".html");
+      const htmlFilePath = path.join(distDir, htmlFile);
+      const htmlContent = fs.readFileSync(htmlFilePath, "utf-8");
+      const metaTag = `<meta http-equiv="refresh" content="0; URL=http://ladybird.org/${file.replace(".md", "")}/"/>`;
+      const linkTag = `<link rel="canonical" href="http://ladybird.org/${file.replace(".md", "")}/"/>`;
+
+      expect(htmlContent.includes(metaTag)).toBe(true);
+      expect(htmlContent.includes(linkTag)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Simple test suite to confirm the middleware generates and redirects are in place, and that the posts both generate and use the layout to correctly style them.

change in `generate-middleware.ts` is to make string parsing easier in tests by removing uneeded multiline formatting.

```
bun test v1.1.18-canary.1 (6a43f7f5)

tests/middleware.test.ts:
Middleware Compilation
  ✓ HTML Redirects Exist [0.36ms]
  ✓ Redirects Work [0.02ms]

tests/markdown.test.ts:
Markdown Rendering
  ✓ Pages Exist [0.01ms]
  ✓ Layouts Applied [0.19ms]

 4 pass
 0 fail
 10 expect() calls
Ran 4 tests across 2 files. [9.00ms]
```