### PR TITLE
Create `.editorconfig` from prettierrc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,astro,css,mjs,cjs,js,ts}]
+spelling_language = en


### PR DESCRIPTION
The ladybird repo [already has one](https://github.com/LadybirdBrowser/ladybird/blob/master/.editorconfig), so let's add one here as well to make IDEs behave :^). Values are taken from the existing `.prettierrc.mjs`.
