### PR TITLE
⚒ Update image widths to be responsive

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -545,7 +545,8 @@ a {
   background-image: url("../../../assets/img/why-eclipse.svg");
   background-repeat: no-repeat;
   background-size: cover;
-  width: 697px;
+  max-width: 697px;
+  width: 100%;
   height: 1117px;
   display: block;
 }
@@ -682,7 +683,8 @@ a {
   background-image: url("../../../assets/img/news-bg.webp");
   background-repeat: no-repeat;
   background-size: cover;
-  width: 688px;
+  max-width: 688px;
+  width: 100%;
   height: 1117px;
   display: block;
 }
@@ -840,7 +842,8 @@ a {
   background-image: url("../../../assets/img/sponsors-medium-eclipse.svg");
   background-repeat: no-repeat;
   background-size: cover;
-  width: 829px;
+  max-width: 829px;
+  width: 100%;
   height: 1117px;
   display: block;
 }


### PR DESCRIPTION
Fixed an issue with containers that have a background image causing the content to overflow

![image](https://github.com/LadybirdBrowser/ladybird.org/assets/103610104/4d44d76a-d7fc-4493-b958-19a7efd2801a)

![image](https://github.com/LadybirdBrowser/ladybird.org/assets/103610104/6e7ef2ff-0751-4067-9140-f159183384f6)

![image](https://github.com/LadybirdBrowser/ladybird.org/assets/103610104/881f71b3-2d99-4ab2-9b52-be8868582a6e)
