### PR TITLE
Fix x-overflow on small screens

### DIFF
--- a/src/components/global/navigation.astro
+++ b/src/components/global/navigation.astro
@@ -1,7 +1,7 @@
 <header class="p-[20px] bg-[#000] relative">
   <div
     id="header-blobs"
-    class="absolute z-10 md:w-full md:max-w-80 sm:max-w-52 left-0 top-0 scale-125 sm:scale-100 translate-y-[10%] sm:translate-y-0"
+    class="absolute pointer-events-none z-10 top-0 left-0"
   >
     <img src="/assets/img/header-eclipse.svg" alt="Header Gradient Blobs" />
   </div>


### PR DESCRIPTION
Opening this in a new PR because this changes the look of the site. This fixes the side-scrolling issue on mobile, but makes the header blob larger on wider screens (which is what the site did before 05331fa870a43092033668ae55951ffa88f142c6). If making it small was intentional, then I can spend some time on adjusting it more.

New:
<img width="1436" alt="new" src="https://github.com/LadybirdBrowser/ladybird.org/assets/96022404/a03f1b9b-f79f-46f4-90b1-7de01d94d595">

Old:
<img width="1425" alt="old" src="https://github.com/LadybirdBrowser/ladybird.org/assets/96022404/cd3ceae6-7530-423a-93fc-45688a4b8b85">

Small screens look largely the same.