### PR TITLE
fix: zoom out on mobile

### DIFF
--- a/src/components/global/footer.astro
+++ b/src/components/global/footer.astro
@@ -67,7 +67,7 @@
     </div>
 
     <div>
-      <div class="flex sm:flex-col md:flex-row justify-between gap-10">
+      <div class="flex flex-col sm:flex-row md:flex-row justify-between gap-10">
         <div class="h-fit">
           <img class="max-w-48" src="/assets/img/logo-new.webp" alt="Logo" />
         </div>


### PR DESCRIPTION
As described in tailwind docs, by default breakpoints are mobile first, so always unprefixed overrides sm, md, lg, ...

[Tailwind: Working mobile-first](https://tailwindcss.com/docs/responsive-design#working-mobile-first)
[Tailwind: Targeting mobile screens](https://tailwindcss.com/docs/responsive-design#targeting-mobile-screens)
reference: #11