### PR TITLE
Port .donate__box to Tailwind

### DIFF
--- a/src/components/landing/donate.astro
+++ b/src/components/landing/donate.astro
@@ -1,16 +1,20 @@
 <section class="donate">
   <div class="container">
-    <div class="donate__box">
-      <div class="donate__box-content">
-        <h2>Become a <span>Ladybird</span> supporter</h2>
-        <p>
+    <div
+      class="relative z-10 -top-4 bg-[url('assets/img/blurp.webp')] bg-center bg-cover flex justify-center mb-12 text-[#fff]"
+    >
+      <div class="p-6 md:p-8 lg:px-16 lg:py-10">
+        <h2 class="mb-[0.8em] text-3xl lg:mb-[0.4em] lg:text-4xl">
+          Become a <span>Ladybird</span> supporter
+        </h2>
+        <p class="mb-5 max-w-2xl">
           Ladybird is funded entirely by sponsorships and donations from people
           and companies who care about the open web.
-          <p>
+          <p class="mb-5 max-w-2xl">
             We accept one-time and recurring monthly donations via <a
               href="https://donorbox.org/ladybird">Donorbox</a
             >.
-            <p>
+            <p class="mb-5 max-w-2xl">
               If you or your company would like to make a large donation, we
               would be happy to display your logo on this website! Please <a
                 href="mailto:contact@ladybird.org">contact us</a

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -910,67 +910,6 @@ table.sponsor-tiers td:first-child {
   color: black;
 }
 
-.donate__box {
-  position: relative;
-  z-index: 10;
-  top: -20px;
-  background-image: url("../../../assets/img/blurp.webp");
-  background-position: center;
-  background-size: cover;
-  width: 100%;
-  height: 560px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 60px;
-  color: #fff;
-}
-
 .donate .container {
   max-width: none;
-}
-
-@media (min-width: 768px) {
-  .donate__box {
-    height: 435px;
-  }
-}
-
-.donate__box-content {
-  padding: 30px;
-}
-
-@media (min-width: 768px) {
-  .donate__box-content {
-    padding: 40px;
-  }
-}
-
-@media (min-width: 991px) {
-  .donate__box-content {
-    padding: 50px 90px;
-  }
-}
-
-.donate__box h2 {
-  color: #fff;
-  margin-bottom: 0.8em;
-  font-size: 36px;
-}
-
-@media (min-width: 991px) {
-  .donate__box h2 {
-    font-size: 48px;
-    margin-bottom: 0.4em;
-  }
-}
-
-.donate__box p {
-  color: #fff;
-  margin-bottom: 24px;
-  max-width: 832px;
-}
-
-.donate__box a:not(.btn--black) {
-  color: #fff;
 }


### PR DESCRIPTION
This PR ports `.donate__box` to Tailwind and fixes its content being cut off vertically at smaller viewport widths.

Before:
![Before (mobile)](https://github.com/user-attachments/assets/0631c705-024e-4b70-b036-b3ef59989fbd)
![Before (desktop)](https://github.com/user-attachments/assets/03e73787-82cf-4179-bbb9-3f83048c02fe)

After:
![After (mobile)](https://github.com/user-attachments/assets/fd9bc281-d9c8-4441-a89e-cf21f8d15e36)
![After (desktop)](https://github.com/user-attachments/assets/4e1b858d-c6bf-4180-b718-180f8bf41d2b)