### PR TITLE
Port the About section to Tailwind

### DIFF
--- a/src/components/landing/about.astro
+++ b/src/components/landing/about.astro
@@ -1,23 +1,25 @@
-<section class="about" id="about">
+<section id="about" class="text-[#fff] bg-[#000] pt-12 lg:pt-0 px-4">
   <div class="container">
-    <div class="about__grid">
-      <div class="about__grid-item image">
+    <div
+      class="grid grid-cols-[1fr] lg:grid-cols-[1fr_1fr] items-center gap-16"
+    >
+      <div class="-my-4 order-2 lg:order-1">
         <img src="/assets/img/about-2x.webp" alt="" />
       </div>
-      <div class="about__grid-item content">
-        <h2>About <span>Ladybird</span></h2>
-        <p>
+      <div class="order-1 lg:order-2">
+        <h2 class="mb-1">About <span>Ladybird</span></h2>
+        <p class="mb-5 max-w-96">
           Ladybird is a brand-new browser &amp; web engine. Driven by a web
           standards first approach, Ladybird aims to render the modern web with
           good performance, stability and security.
         </p>
-        <p>
+        <p class="mb-5 max-w-96">
           From its humble beginnings as an HTML viewer for the SerenityOS hobby
           operating system project, Ladybird has since grown into a
           cross-platform browser supporting Linux, macOS, and other Unix-like
           systems.
         </p>
-        <p>
+        <p class="mb-5 max-w-96">
           Ladybird is currently in heavy development. We are targeting a first
           Alpha release for early adopters in 2026.
         </p>

--- a/src/components/landing/donate.astro
+++ b/src/components/landing/donate.astro
@@ -1,10 +1,10 @@
 <section class="donate">
   <div class="container">
     <div
-      class="relative z-10 -top-4 bg-[url('/assets/img/blurp.webp')] bg-center bg-cover flex justify-center mb-12 text-[#fff]"
+      class="relative z-10 -top-4 text-[#fff] bg-[url('/assets/img/blurp.webp')] bg-center bg-cover mb-12 flex justify-center"
     >
       <div class="p-6 md:p-8 lg:px-16 lg:py-10">
-        <h2 class="mb-[0.8em] text-3xl lg:mb-[0.4em] lg:text-4xl">
+        <h2 class="text-3xl lg:text-4xl mb-[0.8em] lg:mb-[0.4em]">
           Become a <span>Ladybird</span> supporter
         </h2>
         <p class="mb-5 max-w-2xl">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -236,63 +236,6 @@ a {
   }
 }
 
-.about {
-  background-color: #000;
-  padding: 60px 20px 0 20px;
-}
-
-@media (min-width: 991px) {
-  .about {
-    padding: 0 20px;
-  }
-}
-
-.about__grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  align-items: center;
-  gap: 80px;
-}
-
-@media (min-width: 991px) {
-  .about__grid {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-.about__grid-item h2 {
-  color: #fff;
-  margin-bottom: 6px;
-}
-
-.about__grid-item p {
-  color: #fff;
-  margin-bottom: 24px;
-  max-width: 470px;
-}
-
-.about__grid-item.image {
-  order: 2;
-  margin-top: -20px;
-  margin-bottom: -20px;
-}
-
-@media (min-width: 991px) {
-  .about__grid-item.image {
-    order: 1;
-  }
-}
-
-.about__grid-item.content {
-  order: 1;
-}
-
-@media (min-width: 991px) {
-  .about__grid-item.content {
-    order: 2;
-  }
-}
-
 .why {
   background-color: #000;
   position: relative;


### PR DESCRIPTION
This PR ports the About section (`.about`) to Tailwind and reorders classes in `donate.astro` to be consistent with other files.

Before:
![Before](https://github.com/user-attachments/assets/7398b488-426f-4ec7-9da9-2351aa8e9269)

After:
![After](https://github.com/user-attachments/assets/3845ec08-632a-478e-b2ba-b122c26f46e0)