### PR TITLE
newsletters: add draft feature

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -17,6 +17,7 @@ const newsletter = defineCollection({
   schema: z.object({
     description: z.string().max(280),
     date: z.date(),
+    draft: z.boolean().optional(),
   }),
 });
 

--- a/src/content/newsletters/2024-07-09.mdx
+++ b/src/content/newsletters/2024-07-09.mdx
@@ -1,6 +1,7 @@
 ---
 description: Ladybird browser initiative launched
 date: 2024-07-09
+draft: true
 ---
 
 # Content goes here

--- a/src/content/newsletters/2024-07-20.mdx
+++ b/src/content/newsletters/2024-07-20.mdx
@@ -1,0 +1,11 @@
+---
+description: Ladybird browser initiative launched
+date: 2024-07-20
+draft: true
+---
+
+# Content goes here
+
+This is a test of the draft feature
+
+This page will only appear in development, and not in production

--- a/src/pages/newsletter/[...slug].astro
+++ b/src/pages/newsletter/[...slug].astro
@@ -4,7 +4,9 @@ import Layout from "@/layouts/newsletter.astro";
 import { markdown } from "@/components/md";
 
 export async function getStaticPaths() {
-  const newsletters = await getCollection("newsletters");
+  const newsletters = await getCollection("newsletters", ({ data }) =>
+    import.meta.env.PROD ? data.draft !== true : true
+  );
   return newsletters.map((newsletter) => ({
     params: { slug: newsletter.data.date.toISOString().split("T")[0] },
     props: { newsletter },

--- a/tests/newsletters.test.ts
+++ b/tests/newsletters.test.ts
@@ -1,0 +1,29 @@
+import { expect, test, describe } from "bun:test";
+import fs from "fs";
+import path from "path";
+
+const rootDir: string = path.join(__dirname, "../");
+
+describe("Newsletters", () => {
+  const srcDir = path.join(rootDir, "/src/content/newsletters");
+  const distDir = path.join(rootDir, "/dist/newsletter");
+
+  const mdFiles = fs
+    .readdirSync(srcDir)
+    .filter((file) => file.endsWith(".mdx"));
+
+  test("Draft pages should be excluded in build", async () => {
+    mdFiles.forEach((file) => {
+      const filePath = path.join(srcDir, file);
+      const htmlFile = file.replace(".mdx", "/index.html");
+      const htmlFilePath = path.join(distDir, htmlFile);
+
+      const fileContent = fs.readFileSync(filePath);
+      if (fileContent.toString().includes("draft: true")) {
+        expect(fs.existsSync(htmlFilePath)).toBe(false);
+      } else {
+        expect(fs.existsSync(htmlFilePath)).toBe(true);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Adds the ability to mark a newsletter as a draft, preventing it from being included during build, but still being viewable in dev. Contributes towards #19.