### PR TITLE
rss: posts updates

### DIFF
--- a/src/pages/posts.xml.ts
+++ b/src/pages/posts.xml.ts
@@ -8,13 +8,15 @@ export async function GET(context: APIContext) {
     title: "Ladybird Browser Posts",
     description: "Ladybird is a brand-new browser &amp; web engine",
     site: context.site!,
-    items: posts.map((post) => ({
-      title: post.data.title,
-      description: post.data.description,
-      author: post.data.author,
-      pubDate: post.data.date,
-      link: `/posts/${post.slug}`,
-    })),
+    items: posts
+      .filter((post) => post.data.type !== "Hidden")
+      .map((post) => ({
+        title: post.data.title,
+        description: post.data.description,
+        author: post.data.author,
+        pubDate: post.data.date,
+        link: `/posts/${post.slug}`,
+      })),
     trailingSlash: false,
   });
 }

--- a/src/pages/posts.xml.ts
+++ b/src/pages/posts.xml.ts
@@ -15,6 +15,7 @@ export async function GET(context: APIContext) {
         description: post.data.description,
         author: post.data.author,
         pubDate: post.data.date,
+        categories: [post.data.type],
         link: `/posts/${post.slug}`,
       })),
     trailingSlash: false,

--- a/tests/rss.test.ts
+++ b/tests/rss.test.ts
@@ -27,8 +27,13 @@ describe("RSS Feeds", () => {
     );
   });
 
-  test("XML should contain entries for every post", async () => {
-    expect(parsedXML.rss.channel.item).toBeArrayOfSize(mdFiles.length);
+  test("XML should contain entries for every non-hidden post", async () => {
+    const nonHiddenMdFiles = mdFiles.filter((file) => {
+      const filePath = path.join(srcDir, file);
+      const fileContent = fs.readFileSync(filePath);
+      return !fileContent.includes("type: Hidden");
+    });
+    expect(parsedXML.rss.channel.item).toBeArrayOfSize(nonHiddenMdFiles.length);
     parsedXML.rss.channel.item.forEach((item: any) => {
       const itemAttributes = Object.keys(item);
       expect(itemAttributes).toEqual(

--- a/tests/rss.test.ts
+++ b/tests/rss.test.ts
@@ -43,6 +43,7 @@ describe("RSS Feeds", () => {
           "description",
           "pubDate",
           "author",
+          "category",
         ])
       );
     });


### PR DESCRIPTION
This PR does two things:
1. Filters out posts of type "Hidden" from the RSS feed. This was a miss from earlier.
2. Adds the `Category` tag to each item. This is populated with the Type from posts.

Afterthought: The `Category` tag could potentially be used to merge together both posts and newsletters into the same feed, just using a category of `Newsletter`.