### PR TITLE
Newsletter: Switch to Buttondown

### DIFF
--- a/src/components/global/footer.astro
+++ b/src/components/global/footer.astro
@@ -13,18 +13,15 @@
 
         <div class="flex flex-col">
           <form
-            action="https://ladybird.us18.list-manage.com/subscribe/post?u=c15e0446263bcb0793a049dd0&id=43762f159d&f_id=00b4c2e1f0"
+            action="https://buttondown.com/api/emails/embed-subscribe/ladybird"
             method="post"
-            id="mc-embedded-subscribe-form"
-            name="mc-embedded-subscribe-form"
             class="form-subscribe validate"
-            target="_self"
-            novalidate=""
+            target="_blank"
           >
             <div class="form-group flex justify-center items-center">
               <input
                 type="email"
-                name="EMAIL"
+                name="email"
                 class="form-control"
                 placeholder="Your e-mail"
                 required


### PR DESCRIPTION
We're migrating from Mailchimp to Buttondown, so let's use the Buttondown form subscribe target :^)