### PR TITLE
Disable applyBaseStyles in the Tailwind Astro integration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,13 @@ import mdx from "@astrojs/mdx";
 // https://astro.build/config
 export default defineConfig({
   site: "https://ladybird.org",
-  integrations: [tailwind(), sitemap(), mdx()],
+  integrations: [
+    tailwind({
+      applyBaseStyles: false,
+    }),
+    sitemap(),
+    mdx(),
+  ],
   // Special case the initial posts from before the astro transition.
   // These are the super-SEO'd links that were shared around.
   redirects: {


### PR DESCRIPTION
This PR disables `applyBaseStyles` in the Tailwind Astro integration because the base styles are already being applied in `global.css`. This fixes two similar stylesheets being generated.