### PR TITLE
Remove redundant static routes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,16 +12,12 @@ export default defineConfig({
   // These are the super-SEO'd links that were shared around.
   redirects: {
     "/announcement": "/posts/announcement",
-    "/announcement/": "/posts/announcement",
     "/announcement.html": "/posts/announcement",
     "/fork": "/posts/fork",
-    "/fork/": "/posts/fork",
     "/fork.html": "/posts/fork",
     "/thanks": "/posts/thanks",
-    "/thanks/": "/posts/thanks",
     "/thanks.html": "/posts/thanks",
     "/why-ladybird": "/posts/why-ladybird",
-    "/why-ladybird/": "/posts/why-ladybird",
     "/why-ladybird.html": "/posts/why-ladybird",
     "/wire.pdf": "/payment-details",
   },


### PR DESCRIPTION
/foo/ and /foo both generate /foo/index.html for the redirect, and GitHub performs the redirect from /foo to /foo/