### PR TITLE
fix(links): add target="_blank" to external links

### DIFF
--- a/src/components/global/footer.astro
+++ b/src/components/global/footer.astro
@@ -98,6 +98,8 @@
         <div class="flex flex-wrap items-center justify-center gap-1">
           <a
             href="https://github.com/LadybirdBrowser/ladybird"
+            target="_blank"
+            rel="noopener noreferrer"
             class="w-8 h-8 flex items-center justify-center rounded-full bg-[#16141b] hover:bg-[#8a64e5]"
           >
             <img src="/assets/img/github.svg" alt="GitHub" />
@@ -105,6 +107,8 @@
 
           <a
             href="https://discord.gg/nvfjVJ4Svh"
+            target="_blank"
+            rel="noopener noreferrer"
             class="w-8 h-8 flex items-center justify-center rounded-full bg-[#16141b] hover:bg-[#8a64e5]"
           >
             <img src="/assets/img/discord.svg" alt="Discord" />
@@ -112,6 +116,8 @@
 
           <a
             href="https://x.com/ladybirdbrowser"
+            target="_blank"
+            rel="noopener noreferrer"
             class="w-8 h-8 flex items-center justify-center rounded-full bg-[#16141b] hover:bg-[#8a64e5]"
           >
             <img src="/assets/img/x.svg" alt="X/Twitter" />


### PR DESCRIPTION
This pull request addresses an issue with the external media links in the footer of our website. Currently, when users click on these links, they navigate away from our site, which can be an inconvenience. To improve the user experience, this PR adds the target="_blank" attribute to the anchor elements of the external media links. This change ensures that when users click on these links, they will open in new tabs, allowing them to easily return to our website after visiting the external media profiles.

Changes Made:
Modified the HTML code in the footer to include the target="_blank" attribute for each external media link.

Motivation:
Improve user experience: By opening the external media links in new tabs, we prevent users from accidentally leaving our website and enable them to seamlessly return to our content.
Best practice: Using target="_blank" for external links is considered a best practice in web development, as it provides a more predictable and consistent user experience.

Testing:
Tested the changes locally to verify that the external media links open in new tabs.
Ensured the overall functionality and appearance of the website were not affected by this change.
Please review and merge this PR to enhance our website's usability and adhere to web development best practices. Thank you!