### PR TITLE
update footer to dynamically display current year

### DIFF
--- a/src/components/global/footer.astro
+++ b/src/components/global/footer.astro
@@ -93,7 +93,7 @@
         class="flex sm:flex-row flex-col gap-10 items-center justify-between py-[30px] pb-5 px-0 border-t-[#303030] border-t-[1px] mt-8 border-solid"
       >
         <div class="[&>p]:text-[#404040] font-normal">
-          <p>© 2024. All rights reserved.</p>
+          <p>© <span id="year"></span>. All rights reserved.</p>
         </div>
         <div class="flex flex-wrap items-center justify-center gap-1">
           <a
@@ -120,4 +120,10 @@
       </div>
     </div>
   </div>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const currentYear = new Date().getFullYear(); 
+      document.getElementById("year").textContent = currentYear.toString(); 
+    });
+  </script>
 </footer>


### PR DESCRIPTION
## Issue #87 
### Changes made
- Replaced the static year text with a `<span id="year"> </span>` element.
<img width="714" alt="Screenshot 2024-08-31 at 4 53 02 PM" src="https://github.com/user-attachments/assets/0acc9a0f-bbd3-44cc-9985-b9b2f0129b3b">

- Added a JavaScript snippet that sets the text content of the span to the current year when the page loads.
<img width="857" alt="Screenshot 2024-08-31 at 4 51 01 PM" src="https://github.com/user-attachments/assets/7dca8927-3f9a-41be-a641-6bf809e097e1">
