### PR TITLE
rss: add newsletter feed

### DIFF
--- a/src/components/global/footer.astro
+++ b/src/components/global/footer.astro
@@ -123,7 +123,14 @@
           </a>
 
           <a
-            href="https://ladybird.org/posts.rss"
+            href="/posts.rss"
+            class="w-8 h-8 flex items-center justify-center rounded-full bg-[#16141b] hover:bg-[#8a64e5]"
+          >
+            <img src="/assets/img/rss.svg" alt="RSS" />
+          </a>
+
+          <a
+            href="/newsletters.rss"
             class="w-8 h-8 flex items-center justify-center rounded-full bg-[#16141b] hover:bg-[#8a64e5]"
           >
             <img src="/assets/img/rss.svg" alt="RSS" />

--- a/src/components/global/head.astro
+++ b/src/components/global/head.astro
@@ -49,3 +49,10 @@ const defaultDescription =
   title="Ladybird Browser Posts"
   href={new URL("posts.rss", Astro.site)}
 />
+
+<link
+  rel="alternate"
+  type="application/rss+xml"
+  title="Ladybird Browser Newsletters"
+  href={new URL("newsletters.rss", Astro.site)}
+/>

--- a/src/pages/newsletters.rss.ts
+++ b/src/pages/newsletters.rss.ts
@@ -1,0 +1,21 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import type { APIContext } from "astro";
+
+export async function GET(context: APIContext) {
+  const newsletters = await getCollection("newsletters");
+  return rss({
+    title: "Ladybird Browser Newsletters",
+    description: "Ladybird is a brand-new browser &amp; web engine",
+    site: context.site!,
+    items: newsletters
+      .filter((newsletter) => !newsletter.data.draft)
+      .map((newsletter) => ({
+        title: newsletter.data.title,
+        description: newsletter.data.description,
+        pubDate: newsletter.data.date,
+        link: `/newsletter/${newsletter.slug}`,
+      })),
+    trailingSlash: false,
+  });
+}

--- a/tests/rss.test.ts
+++ b/tests/rss.test.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 const rootDir: string = path.join(__dirname, "../");
 
-describe("RSS Feeds", () => {
+describe("Posts RSS Feeds", () => {
   const srcDir = path.join(rootDir, "/src/content/posts");
   const distDir = path.join(rootDir, "/dist/");
 
@@ -44,6 +44,49 @@ describe("RSS Feeds", () => {
           "pubDate",
           "author",
           "category",
+        ])
+      );
+    });
+  });
+});
+
+describe("Newsletters RSS Feeds", () => {
+  const srcDir = path.join(rootDir, "/src/content/newsletters");
+  const distDir = path.join(rootDir, "/dist/");
+
+  const mdFiles = fs
+    .readdirSync(srcDir)
+    .filter((file) => file.endsWith(".mdx"));
+  const nonDraftMdFiles = mdFiles.filter((file) => {
+    const filePath = path.join(srcDir, file);
+    const fileContent = fs.readFileSync(filePath);
+    return !fileContent.includes("draft: true");
+  });
+  const xmlFile = fs.readFileSync(path.join(distDir, "newsletters.rss"));
+
+  const parser = new XMLParser();
+  const parsedXML = parser.parse(xmlFile);
+
+  test("RSS Channel includes overall metadata", () => {
+    expect(parsedXML.rss.channel).toEqual(
+      expect.objectContaining({
+        title: "Ladybird Browser Newsletters",
+        description: "Ladybird is a brand-new browser &amp; web engine",
+        link: "https://ladybird.org",
+      })
+    );
+  });
+
+  test("XML should contain entries for every non-draft newsletter", () => {
+    expect(parsedXML.rss.channel.item).toBeArrayOfSize(nonDraftMdFiles.length);
+    parsedXML.rss.channel.item.forEach((item: any) => {
+      const itemAttributes = Object.keys(item);
+      expect(itemAttributes).toEqual(
+        expect.arrayContaining([
+          "title",
+          "link",
+          "description",
+          "pubDate",
         ])
       );
     });


### PR DESCRIPTION
Difference with #211:

- this PR places the new rss link next to other social links.
   <img width="1188" height="716" alt="image" src="https://github.com/user-attachments/assets/35d3ebf2-ffff-4c9e-9b47-6ddd3f6af34e" />
- this PR uses relative path (`/newsletters.rss`) instead of absolute path `https://ladybird.org/newsletters.rss` so it can easily be tested in dev environment
- this PR adds tests for the new RSS feed