### PR TITLE
landing: Link to full build instructions

### DIFF
--- a/src/components/landing/get-involved.astro
+++ b/src/components/landing/get-involved.astro
@@ -3,12 +3,19 @@
     <h2 class="section-heading">Get involved</h2>
     <p>
       We welcome new contributors every week across all areas of the engine.
-      Clone the code, build it, and come say hi.
+      Clone the code, build it, and come say hi. On many development machines it
+      is as simple as this:
     </p>
 
     <pre><code>$ git clone https://github.com/LadybirdBrowser/ladybird.git
 $ cd ladybird
 $ ./Meta/ladybird.py run</code></pre>
+    <p>
+      For more detailed, operating-system-specific information, check out our <a
+        href="https://github.com/LadybirdBrowser/ladybird/tree/master/Documentation/BuildInstructionsLadybird.md"
+        >full build instructions</a
+      >.
+    </p>
 
     <p>
       <strong>Source code:</strong>


### PR DESCRIPTION
Multiple people have been confused by the incomplete build instructions on the website. Add some additional context and a link to the full build instructions. But keep the actual instructions short to avoid overloading the page and to not duplicate too much information.

Fixes LadybirdBrowser/ladybird#8212